### PR TITLE
Rewrite README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,57 @@
 # Talos
-A multi level authorization project
+A file system permission project.
 
 ## The concept
-The authorization in this project is an attempt to conveniently define what users can access what resources. Resources are uniquely identified using a "resource identifier", which is a string, possibly consisting of multiple levels separated by slashes in order to keep them well-organized. The users in the systeam each have a role, which also can inherit permissions of another role. The permissions then can be specified using so-called permission rules. For example: 
+This project aims to provide a convenient description mechanism for file system permissions. Resources are identified using a string consisting of one or more levels separated by slashes. Users of the system each have a role which can inherit permissions of other roles. Permissions are specified using so-called permission rules, which are triplets of a boolean (allow or deny), a role and a resource. For example: 
 
 ```
-Admin > User
+Student > Mara
+Student > Jeffrey
 
-allow User  /
-deny  User  /profile
-allow User  /profile/[id]
-allow Admin /profile
-deny  Admin /profile/*/password
-allow Admin /profile/[id]/password
+allow Admin   /
+allow Student /home/[id]
+allow Mara    /srv/nfs/music
+deny  Jeffrey /home/[id]/config
+deny  Admin   /home/*/personalsecrets
 ```
 
-These are the access rules for a website where people have a profile and everyone can access their own profile, but administrators can also access other people's profiles, except for the password sections.
+## The tools
 
-## Examples
-Here are some examples of valid sets of access rules.
-
-### Multiple inheritances
+### Inheritance
 ```
-B > A
-C > B
+A > B
+B > C
 
-allow A a
-deny  A a/*
-allow B a/b
-allow C a/c
+allow A x
+deny  A x/*
+allow B x/y
+allow C x/z
 ```
-In this case, A has access to a, B has access to both a and a/b and C has access to a, a/b and a/c.
+`A` has access to `x`, `B` has access to both `x` and `x/y` and `C` has access to `x`, `x/y` and `x/z`.
+
+```
+A > B
+
+allow A x/*
+deny  B x/y
+```
+Although `A` has access to `x` and `x/y`, `B` does not have access to `x/y` as inherited access is overridden.
 
 ### Sets
 ```
-Admin > User
+User > Admin
 
-allow User  devices
+allow Admin devices
 deny  User  devices/*
 allow User  devices/{ownedDevices}
 allow User  devices/{public}/control
 allow User  devices/{allowedDevices}/control
-allow Admin devices
 ```
-In this case, a user has access to every device he owns and can control any device to which its owner has granted him access. The administrators however, have access to every device regardless of ownership.
-
-### Overriding inheritance
-```
-B > A
-
-allow A a
-allow A a/b
-deny  B a
-```
-Although it has been specified that every A has access to a and a/b, since B does not have access to a, this overrides the aforementioned access to a and any lower level.
+A user has access to every device he owns and can control any device to which its owner has granted him access. The administrators however, have access to every device regardless of ownership.
 
 ### Multiple matching rules
 ```
-allow A a/*/c
-deny  A a/b/*
+allow A x/*/z
+deny  A x/y/*
 ```
-Both rules match the resource identifier a/b/c, but the identifiers matched by the first rule lie further apart than the identifiers matched by the second rule. Therefore, the second rule is more specific and will be applied, so A does not have access to a/b/c.
+Both rules match the resource identifier `x/y/z`. The identifier most specific on the highest level of difference in specificity takes precedence. Therefore, the second rule is more specific and `A` does not have access to `x/y/z`.


### PR DESCRIPTION
This commit modifies the syntax, examples and text in this README.

Syntax: Order of inheritance is now reversed
Examples: Made them simpler to understand
Text: Adopted for the new examples